### PR TITLE
Makefile updates

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,9 +3,9 @@ GOFILE ?= conduit.go
 OUTFILE ?= conduit
 
 GOBIN := $(GOPATH)/bin
-GOPATH := $(CURDIR)/_vendor
+GOPATH := $(CURDIR)/_vendor:$(GOPATH)
 
-build: clean $(GOFILE)
+build: clean
 	$(GO) build -v -o $(OUTFILE) *.go
 
 clean:
@@ -14,7 +14,7 @@ clean:
 	rm -rf ./_vendor/pkg
 
 install: build
-	$(GO) install
+	@echo $(GOPATH); $(GO) install
 
 run: build
 	./$(OUTFILE)
@@ -27,7 +27,3 @@ cover: install
 
 cover-report: cover
 	$(GO) tool cover -html=./coverage.out
-
-dep-install:
-	$(GO) get
-

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ clean:
 	rm -rf ./_vendor/pkg
 
 install: build
-	@echo $(GOPATH); $(GO) install
+	$(GO) install
 
 run: build
 	./$(OUTFILE)


### PR DESCRIPTION
Fixed an issue preventing the tests from running when the GOBIN environment variable was unset (which is recommended).